### PR TITLE
Rebuild ProfileBioPanel and collaborators.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,3 +501,6 @@ DEPENDENCIES
   wisper
   wisper_subscription (>= 0.2.0)
   yajl-ruby
+
+BUNDLED WITH
+   1.10.2

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -24,13 +24,11 @@ module UsersHelper
   end
 
   Contract String => String
-
   def profile_articles_row(user_name)
     ProfileArticlesRowBuilder.new(user_name, self).to_html
   end
 
   Contract String, String => String
-
   def profile_bio_row(user_name, user_profile)
     ProfileBioRowBuilder.new(user_name, user_profile, self).to_html
   end

--- a/app/helpers/users_helper/profile_bio_header_builder.rb
+++ b/app/helpers/users_helper/profile_bio_header_builder.rb
@@ -7,7 +7,8 @@ require 'current_user_identity'
 class ProfileBioHeaderBuilder
   include Contracts
 
-  HELPER_INPUTS = Contracts::RespondTo[:concat, :content_tag]
+  # :edit_user_path
+  HELPER_INPUTS = Contracts::RespondTo[:concat, :content_tag, :session]
 
   Contract String, HELPER_INPUTS => ProfileBioHeaderBuilder
   def initialize(user_name, h)
@@ -51,14 +52,6 @@ class ProfileBioHeaderBuilder
     default = Struct.new(:name).new ''
     return default if identity.guest_user?
     identity.current_user
-  end
-
-  Contract None => HashOf[Symbol, String]
-  def link_attribs
-    {
-      class: 'btn btn-xs pull-right',
-      href: h.edit_user_path(current_user.slug)
-    }
   end
 
   Contract None => Ox::Element

--- a/app/helpers/users_helper/profile_bio_header_builder.rb
+++ b/app/helpers/users_helper/profile_bio_header_builder.rb
@@ -2,12 +2,13 @@
 require 'contracts'
 
 require 'current_user_identity'
+require_relative '../../services/ox_builder'
+
+require_relative 'profile_bio_header_builder/builder'
 
 # Builds a header element. It contains a button if the named user is logged in.
 class ProfileBioHeaderBuilder
   include Contracts
-
-  ELEMENT_TYPE = Ox::Element
 
   # :edit_user_path
   HELPER_INPUTS = Contracts::RespondTo[:concat, :content_tag, :session]
@@ -24,48 +25,22 @@ class ProfileBioHeaderBuilder
     Ox.dump(native).strip
   end
 
-  Contract None => ELEMENT_TYPE
+  Contract None => Builder::ELEMENT_TYPE
   def native
-    title_text = "Profile Page for #{user_name}"
-    button = make_button if current_user?
-    Services::OxBuilder.new.build do
-      element('h1').tap do |h1|
-        h1[:class] = 'bio'
-        h1 << title_text
-        h1 << button if button
-      end
-    end
+    Builder.build_native user_name, current_user, h
   end
 
-  protected
+  private
 
   attr_reader :h, :user_name
-
-  private
 
   Contract None => CurrentUserIdentity
   def identity
     @identity ||= CurrentUserIdentity.new(h.session)
   end
 
-  Contract None => Bool
-  def current_user?
-    current_user.name == user_name
-  end
-
   Contract None => RespondTo[:name]
   def current_user
-    default = Struct.new(:name).new ''
-    return default if identity.guest_user?
     identity.current_user
-  end
-
-  Contract None => ELEMENT_TYPE
-  def make_button
-    ELEMENT_TYPE.new(:a).tap do |a|
-      a[:class] = 'btn btn-xs pull-right'
-      a[:href] = h.edit_user_path(current_user.slug)
-      a << 'Edit Your Profile'
-    end
   end
 end

--- a/app/helpers/users_helper/profile_bio_header_builder.rb
+++ b/app/helpers/users_helper/profile_bio_header_builder.rb
@@ -7,6 +7,8 @@ require 'current_user_identity'
 class ProfileBioHeaderBuilder
   include Contracts
 
+  ELEMENT_TYPE = Ox::Element
+
   # :edit_user_path
   HELPER_INPUTS = Contracts::RespondTo[:concat, :content_tag, :session]
 
@@ -19,16 +21,20 @@ class ProfileBioHeaderBuilder
 
   Contract None => String
   def to_html
+    Ox.dump(native).strip
+  end
+
+  Contract None => ELEMENT_TYPE
+  def native
     title_text = "Profile Page for #{user_name}"
     button = make_button if current_user?
-    ret = Services::OxBuilder.new.build do
+    Services::OxBuilder.new.build do
       element('h1').tap do |h1|
         h1[:class] = 'bio'
         h1 << title_text
         h1 << button if button
       end
     end
-    Ox.dump(ret).strip
   end
 
   protected
@@ -54,9 +60,9 @@ class ProfileBioHeaderBuilder
     identity.current_user
   end
 
-  Contract None => Ox::Element
+  Contract None => ELEMENT_TYPE
   def make_button
-    Ox::Element.new(:a).tap do |a|
+    ELEMENT_TYPE.new(:a).tap do |a|
       a[:class] = 'btn btn-xs pull-right'
       a[:href] = h.edit_user_path(current_user.slug)
       a << 'Edit Your Profile'

--- a/app/helpers/users_helper/profile_bio_header_builder/builder.rb
+++ b/app/helpers/users_helper/profile_bio_header_builder/builder.rb
@@ -1,0 +1,27 @@
+
+require 'contracts'
+
+require 'current_user_identity'
+require_relative '../../../services/ox_builder'
+
+require_relative 'header'
+
+# Builds a header element. It contains a button if the named user is logged in.
+class ProfileBioHeaderBuilder
+  class Builder < Services::OxBuilder
+    include Contracts
+
+    def self.build_native(user_name, current_user, h)
+      title_text = "Profile Page for #{user_name}"
+      edit_path = h.edit_user_path(current_user.slug)
+      button = Button.build_native(edit_path) if current_user.name == user_name
+      Builder.new.build do
+        element('h1').tap do |h1|
+          h1[:class] = 'bio'
+          h1 << title_text
+          h1 << button if button
+        end
+      end
+    end
+  end # class ProfileBioHeaderBuilder::Builder
+end # class ProfileBioHeaderBuilder

--- a/app/helpers/users_helper/profile_bio_header_builder/button.rb
+++ b/app/helpers/users_helper/profile_bio_header_builder/button.rb
@@ -1,0 +1,23 @@
+
+require 'contracts'
+
+require 'current_user_identity'
+require_relative '../../../services/ox_builder'
+
+# Builds a header element. It contains a button if the named user is logged in.
+class ProfileBioHeaderBuilder
+  class Builder < Services::OxBuilder
+    class Button
+      include Contracts
+
+      Contract String => Builder::ELEMENT_TYPE
+      def self.build_native(current_user_edit_path)
+        Builder::ELEMENT_TYPE.new(:a).tap do |a|
+          a[:class] = 'btn btn-xs pull-right'
+          a[:href] = current_user_edit_path
+          a << 'Edit Your Profile'
+        end
+      end
+    end # class ProfileBioHeaderBuilder::Builder::Button
+  end # class ProfileBioHeaderBuilder::Builder
+end # class ProfileBioHeaderBuilder

--- a/app/helpers/users_helper/profile_bio_header_builder/header.rb
+++ b/app/helpers/users_helper/profile_bio_header_builder/header.rb
@@ -1,0 +1,24 @@
+
+require 'contracts'
+
+require 'current_user_identity'
+require_relative '../../../services/ox_builder'
+
+require_relative 'button'
+
+# Builds a header element. It contains a button if the named user is logged in.
+class ProfileBioHeaderBuilder
+  class Builder < Services::OxBuilder
+    class Header
+      include Contracts
+
+      def self.build_native(title_text, button)
+        Ox::Element.new('h1').tap do |h1|
+          h1[:class] = 'bio'
+          h1 << title_text
+          h1 << button if button
+        end
+      end
+    end # class ProfileBioHeaderBuilder::Builder::Header
+  end # class ProfileBioHeaderBuilder::Builder
+end # class ProfileBioHeaderBuilder

--- a/app/helpers/users_helper/profile_bio_panel_builder.rb
+++ b/app/helpers/users_helper/profile_bio_panel_builder.rb
@@ -16,21 +16,48 @@ class ProfileBioPanelBuilder
     self
   end
 
-  Contract None => String
-  def to_html
-    [
-      %(<div class="panel panel-default">),
-      %(<div class="panel-heading">),
-      %(<h3 class="panel-title">User Profile/Bio Information</h3>),
-      %(</div>),  # panel-heading
-      %(<div class="panel-body">),
-      @user_profile,
-      %(</div>),  # panel-body
-      %(</div>)   # panel panel-default
-    ].join
+  Contract None => Ox::Element
+  def to_ox
+    Ox::Element.new('div').tap do |outer_div|
+      outer_div[:class] = 'panel panel-default'
+      outer_div << panel_heading
+      outer_div << wrap_profile
+    end # outer_div
   end
 
-  protected
+  Contract None => String
+  def to_html
+    Ox.default_options = { indent: 0, encoding: 'UTF-8' }
+    Ox.dump(to_ox).tr("\n", '')
+  end
+
+  private
+
+  Contract None => Ox::Element
+  def panel_heading
+    Ox::Element.new('div').tap do |ph|
+      ph[:class] = 'panel-heading'
+      ph << Ox::Element.new('h3').tap do |h3|
+        h3[:class] = 'panel-title'
+        h3 << 'User Profile/Bio Information'
+      end
+    end # div.panel-heading
+  end
+
+  Contract None => Ox::Element
+  def parse_profile
+    Ox.parse user_profile
+  rescue Ox::ParseError # no outer/leading element markup; content only
+    Ox::Element.new('p').tap { |p| p << user_profile }
+  end
+
+  Contract None => Ox::Element
+  def wrap_profile
+    Ox::Element.new('div').tap do |pb|
+      pb[:class] = 'panel-body'
+      pb << parse_profile
+    end
+  end
 
   attr_reader :h, :user_profile
 end

--- a/app/helpers/users_helper/profile_bio_panel_builder.rb
+++ b/app/helpers/users_helper/profile_bio_panel_builder.rb
@@ -1,49 +1,11 @@
 
 require 'contracts'
-
-class OxBuilder
-  include Contracts
-
-  Contract Maybe[Proc] => OxBuilder
-  def initialize
-    Ox.default_options = { indent: 0, encoding: 'UTF-8' }
-    self
-  end
-
-  Contract None => String
-  def dump
-    Ox.dump doc
-  end
-
-  private
-
-  Contract String, Maybe[Proc] => Ox::Element
-  def element(name)
-    Ox::Element.new(name).tap { |ret| yield ret if block_given? }
-  end
-
-  Contract String, String => Ox::Element
-  def link_to(text, url)
-    element('a').tap do |elem|
-      elem[:href] = url
-      elem << text
-    end
-  end
-
-  Contract None => Ox::Document
-  def doc
-    @doc ||= new_doc
-  end
-
-  Contract None => Ox::Document
-  def new_doc
-    Ox::Document.new
-  end
-end # class OxBuilder
+# FIXME: Forced `require_relative`.
+require_relative '../../services/ox_builder'
 
 # Builds a Bootstrap panel with a profile's biodata/"profile" information.
 class ProfileBioPanelBuilder
-  class Builder < OxBuilder
+  class Builder < Services::OxBuilder
     include Contracts
 
     attr_reader :outer_div
@@ -78,7 +40,7 @@ class ProfileBioPanelBuilder
 
     private
 
-    Contract None => Ox::Element
+    Contract None => ELEMENT_TYPE
     def panel_heading
       element('div').tap do |ph|
         ph[:class] = 'panel-heading'
@@ -89,7 +51,7 @@ class ProfileBioPanelBuilder
       end # div.panel-heading
     end
 
-    Contract None => Ox::Element
+    Contract None => ELEMENT_TYPE
     def wrap_profile
       element('div').tap do |pb|
         pb[:class] = 'panel-body'
@@ -102,7 +64,7 @@ class ProfileBioPanelBuilder
     attr_reader :default_outer_div_class, :user_profile
 
     # Called from #to_ox > #wrap_profile
-    Contract None => Ox::Element
+    Contract None => ELEMENT_TYPE
     def parse_profile
       Ox.parse user_profile
     rescue Ox::ParseError # no outer/leading element markup; content only

--- a/app/helpers/users_helper/profile_bio_panel_builder.rb
+++ b/app/helpers/users_helper/profile_bio_panel_builder.rb
@@ -1,102 +1,29 @@
 
 require 'contracts'
-# FIXME: Forced `require_relative`.
-require_relative '../../services/ox_builder'
+
+require_relative 'profile_bio_panel_builder/builder'
 
 # Builds a Bootstrap panel with a profile's biodata/"profile" information.
 class ProfileBioPanelBuilder
-  class Builder < Services::OxBuilder
-    include Contracts
-
-    attr_reader :outer_div
-
-    Contract String, Maybe[Proc] => Builder
-    def initialize(user_profile)
-      super()
-      @default_outer_div_class = 'panel panel-default'
-      @user_profile = user_profile
-      self
-    end
-
-    Contract Maybe[String] => Builder
-    def build_outer_div(css_class = default_outer_div_class)
-      @outer_div = element('div').tap do |el|
-        el[:class] = css_class
-      end
-      self
-    end
-
-    Contract None => Builder
-    def build_panel_heading
-      @outer_div << panel_heading
-      self
-    end
-
-    Contract None => Builder
-    def build_profile
-      @outer_div << wrap_profile
-      self
-    end
-
-    private
-
-    Contract None => ELEMENT_TYPE
-    def panel_heading
-      element('div').tap do |ph|
-        ph[:class] = 'panel-heading'
-        ph << element('h3').tap do |h3|
-          h3[:class] = 'panel-title'
-          h3 << 'User Profile/Bio Information'
-        end
-      end # div.panel-heading
-    end
-
-    Contract None => ELEMENT_TYPE
-    def wrap_profile
-      element('div').tap do |pb|
-        pb[:class] = 'panel-body'
-        pb << parse_profile
-      end
-    end
-
-    # private
-
-    attr_reader :default_outer_div_class, :user_profile
-
-    # Called from #to_ox > #wrap_profile
-    Contract None => ELEMENT_TYPE
-    def parse_profile
-      Ox.parse user_profile
-    rescue Ox::ParseError # no outer/leading element markup; content only
-      element('p').tap { |p| p << user_profile }
-    end
-  end # class Builder
-
   include Contracts
 
-  # FIXME: Apparent bug in shared helper 'a_profile_bio_panel.rb' called from
-  #        'profile_bio_panel_builder_spec.rb'.
-  FIXME_HELPER = Maybe[RespondTo[:concat, :content_tag]]
-
-  Contract String, FIXME_HELPER => Any
-  def initialize(user_profile, h)
+  Contract String => Any
+  def initialize(user_profile)
     @user_profile = user_profile
-    @h = h
     self
   end
 
   Contract None => String
   def to_html
-    Ox.dump(to_ox).tr("\n", '')
+    reformat Ox.dump(Builder.build_native user_profile)
   end
 
   private
 
-  attr_reader :h, :user_profile
-
-  Contract None => Ox::Element
-  def to_ox
-    Builder.new(user_profile)
-      .build_outer_div.build_panel_heading.build_profile.outer_div
+  Contract String => String
+  def reformat(input)
+    input.tr("\n", '')
   end
-end
+
+  attr_reader :h, :user_profile
+end # class ProfileBioPanelBuilder

--- a/app/helpers/users_helper/profile_bio_panel_builder.rb
+++ b/app/helpers/users_helper/profile_bio_panel_builder.rb
@@ -1,8 +1,115 @@
 
 require 'contracts'
 
+class OxBuilder
+  include Contracts
+
+  Contract Maybe[Proc] => OxBuilder
+  def initialize
+    Ox.default_options = { indent: 0, encoding: 'UTF-8' }
+    self
+  end
+
+  Contract None => String
+  def dump
+    Ox.dump doc
+  end
+
+  private
+
+  Contract String, Maybe[Proc] => Ox::Element
+  def element(name)
+    Ox::Element.new(name).tap { |ret| yield ret if block_given? }
+  end
+
+  Contract String, String => Ox::Element
+  def link_to(text, url)
+    element('a').tap do |elem|
+      elem[:href] = url
+      elem << text
+    end
+  end
+
+  Contract None => Ox::Document
+  def doc
+    @doc ||= new_doc
+  end
+
+  Contract None => Ox::Document
+  def new_doc
+    Ox::Document.new
+  end
+end # class OxBuilder
+
 # Builds a Bootstrap panel with a profile's biodata/"profile" information.
 class ProfileBioPanelBuilder
+  class Builder < OxBuilder
+    include Contracts
+
+    attr_reader :outer_div
+
+    Contract String, Maybe[Proc] => Builder
+    def initialize(user_profile)
+      super()
+      @default_outer_div_class = 'panel panel-default'
+      @user_profile = user_profile
+      self
+    end
+
+    Contract Maybe[String] => Builder
+    def build_outer_div(css_class = default_outer_div_class)
+      @outer_div = element('div').tap do |el|
+        el[:class] = css_class
+      end
+      self
+    end
+
+    Contract None => Builder
+    def build_panel_heading
+      @outer_div << panel_heading
+      self
+    end
+
+    Contract None => Builder
+    def build_profile
+      @outer_div << wrap_profile
+      self
+    end
+
+    private
+
+    Contract None => Ox::Element
+    def panel_heading
+      element('div').tap do |ph|
+        ph[:class] = 'panel-heading'
+        ph << element('h3').tap do |h3|
+          h3[:class] = 'panel-title'
+          h3 << 'User Profile/Bio Information'
+        end
+      end # div.panel-heading
+    end
+
+    Contract None => Ox::Element
+    def wrap_profile
+      element('div').tap do |pb|
+        pb[:class] = 'panel-body'
+        pb << parse_profile
+      end
+    end
+
+    # private
+
+    attr_reader :default_outer_div_class, :user_profile
+
+    # Called from #to_ox > #wrap_profile
+    Contract None => Ox::Element
+    def parse_profile
+      Ox.parse user_profile
+    rescue Ox::ParseError # no outer/leading element markup; content only
+      element('p').tap { |p| p << user_profile }
+    end
+  end # class Builder
+
   include Contracts
 
   # FIXME: Apparent bug in shared helper 'a_profile_bio_panel.rb' called from
@@ -16,48 +123,18 @@ class ProfileBioPanelBuilder
     self
   end
 
-  Contract None => Ox::Element
-  def to_ox
-    Ox::Element.new('div').tap do |outer_div|
-      outer_div[:class] = 'panel panel-default'
-      outer_div << panel_heading
-      outer_div << wrap_profile
-    end # outer_div
-  end
-
   Contract None => String
   def to_html
-    Ox.default_options = { indent: 0, encoding: 'UTF-8' }
     Ox.dump(to_ox).tr("\n", '')
   end
 
   private
 
-  Contract None => Ox::Element
-  def panel_heading
-    Ox::Element.new('div').tap do |ph|
-      ph[:class] = 'panel-heading'
-      ph << Ox::Element.new('h3').tap do |h3|
-        h3[:class] = 'panel-title'
-        h3 << 'User Profile/Bio Information'
-      end
-    end # div.panel-heading
-  end
-
-  Contract None => Ox::Element
-  def parse_profile
-    Ox.parse user_profile
-  rescue Ox::ParseError # no outer/leading element markup; content only
-    Ox::Element.new('p').tap { |p| p << user_profile }
-  end
-
-  Contract None => Ox::Element
-  def wrap_profile
-    Ox::Element.new('div').tap do |pb|
-      pb[:class] = 'panel-body'
-      pb << parse_profile
-    end
-  end
-
   attr_reader :h, :user_profile
+
+  Contract None => Ox::Element
+  def to_ox
+    Builder.new(user_profile)
+      .build_outer_div.build_panel_heading.build_profile.outer_div
+  end
 end

--- a/app/helpers/users_helper/profile_bio_panel_builder.rb
+++ b/app/helpers/users_helper/profile_bio_panel_builder.rb
@@ -15,7 +15,12 @@ class ProfileBioPanelBuilder
 
   Contract None => String
   def to_html
-    reformat Ox.dump(Builder.build_native user_profile)
+    reformat Ox.dump(native)
+  end
+
+  Contract None => Builder::ELEMENT_TYPE
+  def native
+    Builder.build_native user_profile
   end
 
   private

--- a/app/helpers/users_helper/profile_bio_panel_builder/builder.rb
+++ b/app/helpers/users_helper/profile_bio_panel_builder/builder.rb
@@ -1,0 +1,69 @@
+
+require 'contracts'
+# FIXME: Forced `require_relative`.
+require_relative '../../../services/ox_builder'
+
+# Builds a Bootstrap panel with a profile's biodata/"profile" information.
+class ProfileBioPanelBuilder
+  class Builder < Services::OxBuilder
+    include Contracts
+
+    attr_reader :outer_div
+
+    Contract String, Maybe[Proc] => Builder
+    def initialize(user_profile)
+      super()
+      @default_outer_div_class = 'panel panel-default'
+      @user_profile = user_profile
+      self
+    end
+
+    Contract String, Maybe[String] => ELEMENT_TYPE
+    def self.build_native(user_profile, css_class = 'panel panel-default')
+      Builder.new(user_profile).build do
+        outer_div = outer_div_with css_class
+        outer_div << panel_heading
+        outer_div << wrap_profile
+        outer_div
+      end
+    end
+
+    private
+
+    Contract String => ELEMENT_TYPE
+    def outer_div_with(css_class)
+      element('div').tap { |el| el[:class] = css_class }
+    end
+
+    Contract None => ELEMENT_TYPE
+    def panel_heading
+      element('div').tap do |ph|
+        ph[:class] = 'panel-heading'
+        ph << element('h3').tap do |h3|
+          h3[:class] = 'panel-title'
+          h3 << 'User Profile/Bio Information'
+        end
+      end # div.panel-heading
+    end
+
+    Contract None => ELEMENT_TYPE
+    def wrap_profile
+      element('div').tap do |pb|
+        pb[:class] = 'panel-body'
+        pb << parse_profile
+      end
+    end
+
+    # private
+
+    attr_reader :default_outer_div_class, :user_profile
+
+    # Called from #to_ox > #wrap_profile
+    Contract None => ELEMENT_TYPE
+    def parse_profile
+      Ox.parse user_profile
+    rescue Ox::ParseError # no outer/leading element markup; content only
+      element('p').tap { |p| p << user_profile }
+    end
+  end # class ProfileBioPanelBuilder::Builder
+end # class ProfileBioPanelBuilder

--- a/app/helpers/users_helper/profile_bio_row_builder.rb
+++ b/app/helpers/users_helper/profile_bio_row_builder.rb
@@ -18,12 +18,7 @@ class ProfileBioRowBuilder
 
   Contract None => String
   def to_html
-    outer_div = outer_container do |div|
-      div['class'] = 'row'
-      div << ProfileBioHeaderBuilder.new(user_name, h).to_html
-      div << ProfileBioPanelBuilder.new(user_profile).to_html
-    end
-    reformat_html_output outer_div
+    reformat_html_output Ox.dump(native)
   end
 
   protected
@@ -32,14 +27,24 @@ class ProfileBioRowBuilder
 
   private
 
-  Contract Proc => String
+  ELEMENT_TYPE = Ox::Element
+
+  Contract None => ELEMENT_TYPE
+  def native
+    outer_container do |div|
+      div['class'] = 'row'
+      div << ProfileBioHeaderBuilder.new(user_name, h).native
+      div << ProfileBioPanelBuilder.new(user_profile).native
+    end
+  end
+
+  Contract Proc => ELEMENT_TYPE
   def outer_container
-    doc = Nokogiri::HTML::Document.new
-    Nokogiri::XML::Element.new('div', doc).tap { |div| yield div }.to_html
+    ELEMENT_TYPE.new('div').tap { |div| yield div }
   end
 
   Contract String => String
   def reformat_html_output(markup)
-    markup.lines.each(&:strip!).join
+    markup.tr "\n", ''
   end
 end

--- a/app/helpers/users_helper/profile_bio_row_builder.rb
+++ b/app/helpers/users_helper/profile_bio_row_builder.rb
@@ -16,23 +16,12 @@ class ProfileBioRowBuilder
     self
   end
 
-  # NOTE: PAY ATTENTION! WTF WORKAROUND IN PROGRESS!
-  # This started out as a fairly conventional Rails view-helper method, with the
-  # outer block below appearing as:
-  #     h.content_tag :div, nil, { class: 'row' }, false do
-  #       # innards pretty much as is
-  #     end
-  # The WTF is that, despite the very explicit `false` parameter to #content_tag
-  # (which should disable escaping), the content added by the block WAS escaped
-  # (and thus invalid as HTML).
-  #
-  # Nokogiri, the Swiss Army Nuclear Ginsu Chainsaw, to the rescue!
   Contract None => String
   def to_html
     outer_div = outer_container do |div|
       div['class'] = 'row'
       div << ProfileBioHeaderBuilder.new(user_name, h).to_html
-      div << ProfileBioPanelBuilder.new(user_profile, h).to_html
+      div << ProfileBioPanelBuilder.new(user_profile).to_html
     end
     reformat_html_output outer_div
   end

--- a/app/services/ox_builder.rb
+++ b/app/services/ox_builder.rb
@@ -1,0 +1,44 @@
+
+require 'contracts'
+
+module Services
+  class OxBuilder
+    include Contracts
+
+    DOCUMENT_TYPE = Ox::Document
+    ELEMENT_TYPE = Ox::Element
+
+    Contract None => OxBuilder
+    def initialize
+      Ox.default_options = { indent: 0, encoding: 'UTF-8' }
+      self
+    end
+
+    Contract Proc => ELEMENT_TYPE
+    def build(&block)
+      instance_eval(&block)
+    end
+
+    Contract None => DOCUMENT_TYPE
+    def doc
+      @doc ||= new_doc
+    end
+
+    Contract Any => String
+    def dump(what)
+      Ox.dump what
+    end
+
+    private
+
+    Contract String => ELEMENT_TYPE
+    def element(name)
+      Ox::Element.new name
+    end
+
+    Contract None => DOCUMENT_TYPE
+    def new_doc
+      Ox::Document.new
+    end
+  end # class Services::OxBuilder
+end

--- a/app/services/ox_builder.rb
+++ b/app/services/ox_builder.rb
@@ -38,7 +38,7 @@ module Services
 
     Contract None => DOCUMENT_TYPE
     def new_doc
-      Ox::Document.new
+      @doc = Ox::Document.new
     end
   end # class Services::OxBuilder
 end

--- a/spec/helpers/users_helper/index_row_builder_spec.rb
+++ b/spec/helpers/users_helper/index_row_builder_spec.rb
@@ -74,7 +74,7 @@ describe IndexRowBuilder, type: :request do
     context 'when the target user is the current user' do
       let(:actual) { obj.build default_user }
 
-      fit 'returns an HTML table row' do
+      it 'returns an HTML table row' do
         expect(actual).to match %r{\A<tr.+</tr>\z}
       end
 

--- a/spec/helpers/users_helper/profile_bio_header_builder_spec.rb
+++ b/spec/helpers/users_helper/profile_bio_header_builder_spec.rb
@@ -1,0 +1,64 @@
+
+require 'spec_helper'
+
+describe ProfileBioHeaderBuilder, type: :request do
+  let(:helper) do
+    Class.new do
+      include ActionView::Helpers::TextHelper
+      include ActionView::Context
+      include Rails.application.routes.url_helpers
+      attr_reader :session
+      def initialize(*)
+        @session = {}
+        self
+      end
+    end.new
+  end
+
+  describe 'supports initialisation with' do
+    it 'two required parameters' do
+      expect { described_class.new }.to raise_error ArgumentError, /0 for 2/
+    end
+
+    it 'the first of two parameters being an (unchecked) user-name string' do
+      expect { described_class.new 'anything', helper }.not_to raise_error
+    end
+
+    it 'the second of two parameters being a Rails view-helper instance' do
+      expect { described_class.new 'anything', 'oops' }.to raise_error do |e|
+        expect(e).to be_a ParamContractError
+        expect(e.message).to match(/Actual: "oops"/)
+        expected = 'Expected: ' \
+          '(a value that responds to [:concat, :content_tag]),'
+        expect(e.message).to match Regexp.escape(expected)
+      end
+    end
+  end # describe 'supports initialisation with'
+
+  describe 'supports a #to_html instance method that' do
+    context 'when called while no user is logged in' do
+      let(:actual) { obj.to_html }
+      let(:obj) { described_class.new user_name, helper }
+      let(:user_name) { 'Thaddeus Q Bostwick-Huddle LXVI' }
+
+      it 'returns an HTML string' do
+        expect(actual).to be_a String
+        expect { Ox.parse actual }.not_to raise_error
+      end
+
+      describe 'returns an HTML string that' do
+        let(:parsed) { Ox.parse actual }
+
+        it 'is enclosed by an :h1 tag pair with the CSS class "bio"' do
+          expect(parsed.value).to eq 'h1'
+          expect(parsed[:class]).to eq 'bio'
+        end
+
+        it 'has correct enclosed text, including the specified user name' do
+          h1 = parsed.nodes.first
+          expect(h1).to eq 'Profile Page for ' + user_name
+        end
+      end # context 'when called while no user is logged in'
+    end
+  end # describe 'supports a #to_html instance method that'
+end

--- a/spec/helpers/users_helper/profile_bio_header_builder_spec.rb
+++ b/spec/helpers/users_helper/profile_bio_header_builder_spec.rb
@@ -122,4 +122,26 @@ describe ProfileBioHeaderBuilder, type: :request do
       end
     end # context 'when called while a user other than the target is logged in'
   end # describe 'supports a #to_html instance method that'
+
+  describe 'supports a #native instance method that' do
+    context 'when called while no user is logged in' do
+      let(:actual) { obj.native }
+      let(:obj) { described_class.new user_name, helper }
+      let(:user_name) { 'Thaddeus Q Bostwick-Huddle LXVI' }
+
+      it 'returns an :h1 element' do
+        expect(actual.value).to eq 'h1'
+      end
+
+      it 'has a :class attribute value of "bio" and no other attributes' do
+        expect(actual.attributes.count).to eq 1
+        expect(actual[:class]).to eq 'bio'
+      end
+
+      it 'has a single child node, the expected title including user name' do
+        expect(actual.nodes.count).to eq 1
+        expect(actual.nodes.first).to eq "Profile Page for #{user_name}"
+      end
+    end # context 'when called while no user is logged in'
+  end # describe 'supports a #native instance method that'
 end

--- a/spec/helpers/users_helper/profile_bio_header_builder_spec.rb
+++ b/spec/helpers/users_helper/profile_bio_header_builder_spec.rb
@@ -31,7 +31,7 @@ describe ProfileBioHeaderBuilder, type: :request do
         expect(e).to be_a ParamContractError
         expect(e.message).to match(/Actual: "oops"/)
         expected = 'Expected: ' \
-          '(a value that responds to [:concat, :content_tag]),'
+          '(a value that responds to [:concat, :content_tag, :session]),'
         expect(e.message).to match Regexp.escape(expected)
       end
     end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -87,7 +87,7 @@ describe UsersHelper do
       fragment_builder = lambda do |markup|
         Nokogiri.parse(markup).children.last
       end
-      it_behaves_like 'a profile bio panel', fragment_builder, helper
+      it_behaves_like 'a profile bio panel', fragment_builder
     end # describe 'has a second child element that'
   end # describe :profile_bio_row
 end # describe UsersHelper

--- a/spec/services/ox_builder_spec.rb
+++ b/spec/services/ox_builder_spec.rb
@@ -85,6 +85,7 @@ describe Services::OxBuilder do
 
   describe 'has an #element instance method which' do
     let(:elem) { obj.build { element('hr') } }
+
     it 'is not a public method' do
       expect { obj.element 'p' }.to raise_error NoMethodError, /private method/
     end
@@ -97,4 +98,30 @@ describe Services::OxBuilder do
       expect(elem).to be_a Ox::Element
     end
   end # describe 'has an #element instance method which'
+
+  describe 'has a #new_doc instance method which' do
+    it 'is not a public method' do
+      expect { obj.new_doc }.to raise_error NoMethodError, /private method/
+    end
+
+    it 'returns a new instance each time it is called' do
+      doc1 = nil
+      doc2 = nil
+      doc2a = nil
+      doc3 = nil
+      doc3a = nil
+      obj.build do
+        doc1 = doc
+        doc2 = new_doc
+        doc2a = doc
+        doc3 = new_doc
+        doc3a = doc
+        element('hr')
+      end
+      expect(doc1).not_to be doc2
+      expect(doc2).to be doc2a
+      expect(doc3).not_to be doc2
+      expect(doc3a).to be doc3
+    end
+  end # describe 'has a #new_doc instance method which'
 end # describe Services::OxBuilder

--- a/spec/services/ox_builder_spec.rb
+++ b/spec/services/ox_builder_spec.rb
@@ -1,0 +1,100 @@
+
+require 'spec_helper'
+
+# FIXME: Once `ox_builder.rb` is a uniquely-named file, kill this.
+require_relative '../../app/services/ox_builder'
+
+describe Services::OxBuilder do
+  let(:obj) { described_class.new }
+  let(:new_el) { described_class::ELEMENT_TYPE.new 'p' }
+
+  describe 'supports initialisation with' do
+    it 'no parameters' do
+      expect { described_class.new }.not_to raise_error
+      expect { described_class.new :bogus }.to raise_error do |e|
+        expect(e).to be_a ParamContractError
+        expect(e.message).to match Regexp.escape('Expected: None')
+      end
+    end
+  end # describe 'supports initialisation with'
+
+  describe 'has a #build instance method which' do
+    it 'takes no parameters' do
+      expect { obj.build :bogus }.to raise_error do |e|
+        expect(e).to be_a ParamContractError
+        expect(e.message).to match 'Expected: Proc'
+      end
+      proc = -> {}
+      expect { obj.build proc }.to raise_error ArgumentError, /1 for 0/
+    end
+
+    it 'requires a block' do
+      expect { obj.build }.to raise_error do |e|
+        expect(e).to be_a ParamContractError
+        expect(e.message).to match 'Expected: Proc'
+      end
+      el = new_el # must be in local/callable scope when nested block created
+      expect { obj.build { el } }.not_to raise_error
+    end
+
+    it 'requires that that block return an Ox::Element instance' do
+      el = new_el # must be in local/callable scope when nested block created
+      expect { obj.build { el } }.not_to raise_error
+    end
+
+    it 'yields to that block in instance scope' do
+      expect(obj.instance_variables).not_to include :@foo
+      el = described_class::ELEMENT_TYPE.new 'p'
+      obj.build do
+        instance_variable_set :@foo, true
+        el
+      end
+      expect(obj.instance_variable_get :@foo).to be true
+    end
+  end # describe 'has a #build instance method which'
+
+  describe 'has a #doc instance method which' do
+    it 'returns an Ox::Document instance' do
+      expect(described_class.new.doc).to be_a Ox::Document
+    end
+
+    it 'repeatedly returns the same Ox::Document instance' do
+      obj = described_class.new
+      doc = obj.doc
+      expect(obj.doc).to be doc
+    end
+  end # describe 'has a #doc instance method which'
+
+  describe 'has a #dump instance method which' do
+    it 'accepts anything and produces an XML-style string' do
+      expect(obj.dump 42).to eq "<i>42</i>\n"
+      expect(obj.dump :foo).to eq "<m>foo</m>\n"
+      expect(obj.dump 'test').to eq "<s>test</s>\n"
+      expect(obj.dump nil).to eq "<z/>\n"
+      expect(obj.dump new_el).to eq "\n<p/>\n" # leading newline introduced
+    end
+
+    it 'correctly renders nested Ox elements' do
+      input = '<p>This <em>is</em> a test.</p>'
+      top_el = Ox.load input
+      expected = "\n<p>This \n<em>is</em> a test.</p>\n"
+      # NOTE: Do NOT simply call `Ox.dump` here; that will use default defaults.
+      expect(obj.dump top_el).to eq expected
+    end
+  end # describe 'has a #dump instance method which'
+
+  describe 'has an #element instance method which' do
+    let(:elem) { obj.build { element('hr') } }
+    it 'is not a public method' do
+      expect { obj.element 'p' }.to raise_error NoMethodError, /private method/
+    end
+
+    it 'can of course be called from the block passed to #build' do
+      expect(obj.dump elem).to eq "\n<hr/>\n"
+    end
+
+    it 'returns an Ox::Element instance' do
+      expect(elem).to be_a Ox::Element
+    end
+  end # describe 'has an #element instance method which'
+end # describe Services::OxBuilder

--- a/spec/support/shared_examples/users_helper/a_profile_bio_panel.rb
+++ b/spec/support/shared_examples/users_helper/a_profile_bio_panel.rb
@@ -1,9 +1,9 @@
 
-shared_examples 'a profile bio panel' do |fragment_builder, h|
+shared_examples 'a profile bio panel' do |fragment_builder|
   let(:user_entity) { UserFactory.entity_class }
   let(:user) { user_entity.new FactoryGirl.attributes_for(:user) }
   let(:fragment) do
-    builder = ProfileBioPanelBuilder.new user.profile.squish, h
+    builder = ProfileBioPanelBuilder.new user.profile.squish
     fragment_builder.call builder.to_html
   end
 


### PR DESCRIPTION
More fun with #285.

`ProfileBioPanel`, and its two direct collaborators, `ProfileBioHeaderBuilder` and `ProfileBioRowBuilder`, are *marvels* of HTML-as-raw-string slicing and dicing with just enough Nokogiri thrown in to confuse the situation. :astonished: